### PR TITLE
Updated fzaninotto/faker dependency definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "fzaninotto/faker" : "1.6.*"
+	"fzaninotto/faker" : "^1.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0"


### PR DESCRIPTION
Trying to use this library with the latest version of the faker library (v1.7.1) throws a composer error;

factory-muffin-maker currently requires 1.6.*; changed this to ^1.6