### PR TITLE
Updated faker dependency to 1.8.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "fzaninotto/faker" : "1.6.*"
+        "fzaninotto/faker" : "1.8.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.0"


### PR DESCRIPTION
Hi!

I'm using this package extensively, but the faker version used is getting quite old, almost two years, missing some of the features, but i'm using faker directly also, and get locked on the 1.6 version.
I had seen the previous pull request #11  closed and I understand the causes.
Maybe you could consider updating a major version to catch up with Faker?

Thanks