### PR TITLE
Add end user ability to extend faker facade and ovverride faker instance

### DIFF
--- a/src/Facade.php
+++ b/src/Facade.php
@@ -27,7 +27,7 @@ class Facade
      *
      * @var \League\FactoryMuffin\Faker\Faker
      */
-    private static $instance;
+    protected static $instance;
 
     /**
      * Get the underlying faker instance.


### PR DESCRIPTION
A few minutes ago I wanted to extend my own Faker instance from factory-muffins Faker to add a phpdoc tags for Faker instance API autocompletion

But I loosed this ability due to private access modifier on `Facade::$instance`

Additionally I don't see a valuable reason to leave it `private` on